### PR TITLE
Fix TOML syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ sequence (called _tail_ aka rest _rt_). Sequences are formed of immutable data e
 the same tail, permitting compact representation of hierarchical data.
 
 Add the following dependency to your Cargo.toml file:
-```cargo
-...
+```toml
 [dependencies]
 seq = "0.1.0"
 ```


### PR DESCRIPTION
The format used in `.toml` files is TOML (not Cargo) :P

Before:
![before SS](https://user-images.githubusercontent.com/6709544/31561883-a61a3792-b059-11e7-8a77-a905418da352.png)

After:
![after SS](https://user-images.githubusercontent.com/6709544/31561882-a5f9f3a6-b059-11e7-95b2-5fedfa52ad41.png)
